### PR TITLE
Change lateral line pin in findline.py

### DIFF
--- a/server/ICEP_robotica/findline.py
+++ b/server/ICEP_robotica/findline.py
@@ -17,9 +17,9 @@ right_spd  = num_import_int('E_M2:')         #Speed of the car
 left       = num_import_int('E_T1:')         #Motor Left
 right      = num_import_int('E_T2:')         #Motor Right
 '''
-line_pin_right = 19
+line_pin_right = 20
 line_pin_middle = 16
-line_pin_left = 20
+line_pin_left = 19
 
 forward_speed = 40
 right_speed = 40


### PR DESCRIPTION
Line pins are apparently reversed, that's why robot can't follow the line.
Test and adjust on robot

![Screenshot_2023-02-12-00-59-21-04_99c04817c0de5652397fc8b56c3b3817](https://user-images.githubusercontent.com/123225827/218297585-2c793f0b-ec1f-46c6-84dc-7966d8216276.jpg)

![Screenshot_2023-02-12-00-59-33-61_99c04817c0de5652397fc8b56c3b3817](https://user-images.githubusercontent.com/123225827/218297589-83d544ea-6b33-4fd2-a752-f52dbe8f8114.jpg)

![Screenshot_2023-02-12-01-03-10-73_320a9a695de7cdce83ed5281148d6f19](https://user-images.githubusercontent.com/123225827/218297695-4e60ecc7-f907-42f3-a505-265886d1b80d.jpg)
